### PR TITLE
dependencies not loading for deluge due to openssl deprecation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ RUN \
 	unrar \
 	unzip && \
  apk add --no-cache \
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	libressl2.4-libssl && \
+ apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/testing \
 	deluge && \
 
@@ -20,9 +23,12 @@ RUN \
 	g++ \
 	gcc \
 	libffi-dev \
-	openssl-dev \
 	py-pip \
 	python-dev && \
+
+ apk add --no-cache --virtual=build-dependencies2 \
+	--repository http://nl.alpinelinux.org/alpine/edge/main \
+	libressl-dev && \
 
 # install pip packages
  pip install --no-cache-dir -U \
@@ -37,7 +43,8 @@ RUN \
 
 # cleanup
  apk del --purge \
-	build-dependencies && \
+	build-dependencies \
+	build-dependencies2 && \
  rm -rf \
 	/root/.cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@ MAINTAINER Gonzalo Peci <davyjones@linuxserver.io>, sparklyballs
 # environment variables
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
+# set version label
+ARG BUILD_DATE
+ARG VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+
 # install runtime packages
 RUN \
  apk add --no-cache \

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Change the downloads location in the webui in Preferences->Downloads and use /do
 
 ## Versions
 
++ **30.09.16:** Switch to libressl as openssl deprecated from alpine linux and deluge dependency
+no longer installs.
 + **30.09.16:** Fix umask.
 + **09.09.16:** Add layer badges to README.
 + **30.08.16:** Use pip packages for some critical dependencies.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The [LinuxServer.io][linuxserverurl] team brings you another container release f
 * [Podcast][podcasturl] covers everything to do with getting the most from your Linux Server plus a focus on all things Docker and containerisation!
 
 # linuxserver/deluge
-[![](https://images.microbadger.com/badges/image/linuxserver/deluge.svg)](http://microbadger.com/images/linuxserver/deluge "Get your own image badge on microbadger.com")[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/deluge.svg)][hub][![Docker Stars](https://img.shields.io/docker/stars/linuxserver/deluge.svg)][hub][![Build Status](http://jenkins.linuxserver.io:8080/buildStatus/icon?job=Dockers/LinuxServer.io/linuxserver-deluge)](http://jenkins.linuxserver.io:8080/job/Dockers/job/LinuxServer.io/job/linuxserver-deluge/)
+[![](https://images.microbadger.com/badges/version/linuxserver/deluge.svg)](https://microbadger.com/images/linuxserver/deluge "Get your own version badge on microbadger.com")[![](https://images.microbadger.com/badges/image/linuxserver/deluge.svg)](http://microbadger.com/images/linuxserver/deluge "Get your own image badge on microbadger.com")[![Docker Pulls](https://img.shields.io/docker/pulls/linuxserver/deluge.svg)][hub][![Docker Stars](https://img.shields.io/docker/stars/linuxserver/deluge.svg)][hub][![Build Status](http://jenkins.linuxserver.io:8080/buildStatus/icon?job=Dockers/LinuxServer.io/linuxserver-deluge)](http://jenkins.linuxserver.io:8080/job/Dockers/job/LinuxServer.io/job/linuxserver-deluge/)
 [hub]: https://hub.docker.com/r/linuxserver/deluge/
 
 [deluge](http://deluge-torrent.org/) Deluge is a lightweight, Free Software, cross-platform BitTorrent client.
@@ -70,6 +70,14 @@ Change the downloads location in the webui in Preferences->Downloads and use /do
 ## Info
 
 * Monitor the logs of the container in realtime `docker logs -f deluge`.
+
+* container version number 
+
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' deluge`
+
+* image version number
+
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' linuxserver/deluge`
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Change the downloads location in the webui in Preferences->Downloads and use /do
 
 ## Versions
 
-+ **30.09.16:** Switch to libressl as openssl deprecated from alpine linux and deluge dependency
++ **13.10.16:** Switch to libressl as openssl deprecated from alpine linux and deluge dependency
 no longer installs.
 + **30.09.16:** Fix umask.
 + **09.09.16:** Add layer badges to README.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ Having to switch from openssl to libressl due to alpine deprecation of openssl and deluge being called from the edge repository.
+ closes #12