### PR TITLE
shift to full binary of 7zip with encryption support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
 	deluged \
 	deluge-console \
 	deluge-web \
-	p7zip \
+	p7zip-full \
 	unrar \
 	unzip \
 	libssl1.0.0 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -18,7 +18,7 @@ RUN \
 	deluged \
 	deluge-console \
 	deluge-web \
-	p7zip \
+	p7zip-full \
 	unrar \
 	unzip \
 	libssl1.0.0 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -18,7 +18,7 @@ RUN \
 	deluged \
 	deluge-console \
 	deluge-web \
-	p7zip \
+	p7zip-full \
 	unrar \
 	unzip \
 	libssl1.0.0 \

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Below are the instructions for updating containers:
   ```
   docker run --rm \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  containrrr/watchtower
+  containrrr/watchtower \
   --run-once deluge
   ```
 * You can also remove the old dangling images: `docker image prune`
@@ -191,6 +191,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **02.05.19:** - Install full version of 7zip.
 * **23.03.19:** - Switching to new Base images, shift to arm32v7 tag.
 * **15.11.18:** - Add deluge-console.
 * **11.11.18:** - Rebase to Ubuntu Bionic, add pipeline multiarch logic.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "02.05.19:", desc: "Install full version of 7zip." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "15.11.18:", desc: "Add deluge-console." }
   - { date: "11.11.18:", desc: "Rebase to Ubuntu Bionic, add pipeline multiarch logic." }


### PR DESCRIPTION
https://github.com/linuxserver/docker-deluge/issues/62

7zr does not have encryption support which essentially breaks password protected 7z files. This provides the full standalone 7za binary. 