### PR TITLE
update to 2.x version using deluge ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,14 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
+ if [ -z ${DELUGE_VERSION+x} ]; then \
+	DELUGE="deluged"; \
+ else \
+	DELUGE="deluged=${DELUGE_VERSION}"; \
+ fi && \
  apt-get update && \
  apt-get install -y \
-	deluged \
+	"${DELUGE}" \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,20 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs, aptalca"
 
 # environment variables
+ARG DEBIAN_FRONTEND="noninteractive"
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
 # install software
 RUN \
+ echo "**** add repositories ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
+ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
@@ -20,36 +30,8 @@ RUN \
 	deluge-web \
 	p7zip-full \
 	unrar \
-	unzip \
-	libssl1.0.0 \
-	openssl && \
- echo "**** install build deps ****" && \
- apt-get install -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- echo "**** install pip packages ****" && \
- pip install --no-cache-dir -U \
-	incremental \
-	crypto \
-	mako \
-	markupsafe \
-	pyopenssl \
-	service_identity \
-	six \
-	twisted \
-	zope.interface && \
+	unzip && \
  echo "**** cleanup ****" && \
- apt-get purge -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- apt-get --purge autoremove -y && \
- apt-get clean && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM lsiobase/ubuntu:bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG DELUGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="sparklyballs, aptalca"
 
@@ -23,14 +22,9 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
- if [ -z ${DELUGE_VERSION+x} ]; then \
-	DELUGE="deluged"; \
- else \
-	DELUGE="deluged=${DELUGE_VERSION}"; \
- fi && \
  apt-get update && \
  apt-get install -y \
-	"${DELUGE}" \
+	deluged \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -23,9 +23,14 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
+ if [ -z ${DELUGE_VERSION+x} ]; then \
+	DELUGE="deluged"; \
+ else \
+	DELUGE="deluged=${DELUGE_VERSION}"; \
+ fi && \
  apt-get update && \
  apt-get install -y \
-	deluged \
+	"${DELUGE}" \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -3,7 +3,6 @@ FROM lsiobase/ubuntu:arm64v8-bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG DELUGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="sparklyballs, aptalca"
 
@@ -23,14 +22,9 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
- if [ -z ${DELUGE_VERSION+x} ]; then \
-	DELUGE="deluged"; \
- else \
-	DELUGE="deluged=${DELUGE_VERSION}"; \
- fi && \
  apt-get update && \
  apt-get install -y \
-	"${DELUGE}" \
+	deluged \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -8,10 +8,20 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs, aptalca"
 
 # environment variables
+ARG DEBIAN_FRONTEND="noninteractive"
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
 # install software
 RUN \
+ echo "**** add repositories ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
+ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
@@ -20,36 +30,8 @@ RUN \
 	deluge-web \
 	p7zip-full \
 	unrar \
-	unzip \
-	libssl1.0.0 \
-	openssl && \
- echo "**** install build deps ****" && \
- apt-get install -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- echo "**** install pip packages ****" && \
- pip install --no-cache-dir -U \
-	incremental \
-	crypto \
-	mako \
-	markupsafe \
-	pyopenssl \
-	service_identity \
-	six \
-	twisted \
-	zope.interface && \
+	unzip && \
  echo "**** cleanup ****" && \
- apt-get purge -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- apt-get --purge autoremove -y && \
- apt-get clean && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -23,9 +23,14 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
+ if [ -z ${DELUGE_VERSION+x} ]; then \
+	DELUGE="deluged"; \
+ else \
+	DELUGE="deluged=${DELUGE_VERSION}"; \
+ fi && \
  apt-get update && \
  apt-get install -y \
-	deluged \
+	"${DELUGE}" \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,7 +3,6 @@ FROM lsiobase/ubuntu:arm32v7-bionic
 # set version label
 ARG BUILD_DATE
 ARG VERSION
-ARG DELUGE_VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="sparklyballs, aptalca"
 
@@ -23,14 +22,9 @@ RUN \
  echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
- if [ -z ${DELUGE_VERSION+x} ]; then \
-	DELUGE="deluged"; \
- else \
-	DELUGE="deluged=${DELUGE_VERSION}"; \
- fi && \
  apt-get update && \
  apt-get install -y \
-	"${DELUGE}" \
+	deluged \
 	deluge-console \
 	deluge-web \
 	p7zip-full \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -8,10 +8,20 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="sparklyballs, aptalca"
 
 # environment variables
+ARG DEBIAN_FRONTEND="noninteractive"
 ENV PYTHON_EGG_CACHE="/config/plugins/.python-eggs"
 
 # install software
 RUN \
+ echo "**** add repositories ****" && \
+ apt-get update && \
+ apt-get install -y \
+	gnupg && \
+ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \
  apt-get install -y \
@@ -20,36 +30,8 @@ RUN \
 	deluge-web \
 	p7zip-full \
 	unrar \
-	unzip \
-	libssl1.0.0 \
-	openssl && \
- echo "**** install build deps ****" && \
- apt-get install -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- echo "**** install pip packages ****" && \
- pip install --no-cache-dir -U \
-	incremental \
-	crypto \
-	mako \
-	markupsafe \
-	pyopenssl \
-	service_identity \
-	six \
-	twisted \
-	zope.interface && \
+	unzip && \
  echo "**** cleanup ****" && \
- apt-get purge -y \
-	libssl-dev \
-	python-dev \
-	build-essential \
-	libffi-dev \
-	python-pip && \
- apt-get --purge autoremove -y && \
- apt-get clean && \
  rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,12 +99,14 @@ pipeline {
     /* ########################
        External Release Tagging
        ######################## */
-    // If this is an os release set release type to none to indicate no external release
-    stage("Set ENV os"){
+    // If this is a custom command to determine version use that command
+    stage("Set tag custom bash"){
       steps{
         script{
-          env.EXT_RELEASE = env.PACKAGE_TAG
-          env.RELEASE_LINK = 'none'
+          env.EXT_RELEASE = sh(
+            script: ''' curl -sX GET http://ppa.launchpad.net/deluge-team/stable/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 '^Package: deluged$' | awk -F ': ' '/Version/{print $2;exit}' ''',
+            returnStdout: true).trim()
+            env.RELEASE_LINK = 'custom_command'
         }
       }
     }
@@ -593,11 +595,11 @@ pipeline {
              "tagger": {"name": "LinuxServer Jenkins","email": "jenkins@linuxserver.io","date": "'${GITHUB_DATE}'"}}' '''
         echo "Pushing New release for Tag"
         sh '''#! /bin/bash
-              echo "Updating base packages to ${PACKAGE_TAG}" > releasebody.json
+              echo "Updating to ${EXT_RELEASE_CLEAN}" > releasebody.json
               echo '{"tag_name":"'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
                      "target_commitish": "master",\
                      "name": "'${EXT_RELEASE_CLEAN}'-ls'${LS_TAG_NUMBER}'",\
-                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**OS Changes:**\\n\\n' > start
+                     "body": "**LinuxServer Changes:**\\n\\n'${LS_RELEASE_NOTES}'\\n**Remote Changes:**\\n\\n' > start
               printf '","draft": false,"prerelease": false}' >> releasebody.json
               paste -d'\\0' start releasebody.json > releasebody.json.done
               curl -H "Authorization: token ${GITHUB_TOKEN}" -X POST https://api.github.com/repos/${LS_USER}/${LS_REPO}/releases -d @releasebody.json.done'''

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -2,7 +2,8 @@
 
 # jenkins variables
 project_name: docker-deluge
-external_type: os
+external_type: na
+custom_version_command: "curl -sX GET http://ppa.launchpad.net/deluge-team/stable/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 '^Package: deluged$' | awk -F ': ' '/Version/{print $2;exit}'"
 release_type: stable
 release_tag: latest
 ls_branch: master

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "09.06.19:", desc: "Update to 2.x using deluge ppa." }
   - { date: "02.05.19:", desc: "Install full version of 7zip." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "15.11.18:", desc: "Add deluge-console." }

--- a/root/etc/services.d/deluge-web/run
+++ b/root/etc/services.d/deluge-web/run
@@ -6,4 +6,4 @@ umask "$UMASK_SET"
 
 exec \
 	s6-setuidgid abc /usr/bin/deluge-web \
-	-d -c /config --loglevel=info
+	-d -c /config --loglevel=warning

--- a/root/etc/services.d/deluge-web/run
+++ b/root/etc/services.d/deluge-web/run
@@ -6,4 +6,4 @@ umask "$UMASK_SET"
 
 exec \
 	s6-setuidgid abc /usr/bin/deluge-web \
-	-c /config --loglevel=info
+	-d -c /config --loglevel=info


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ bump to version 2.x from deluge ppa, query having to change some endpoint for version control.
+ untested on arm64 as my local device needs fixing, so no idea if it will even build !!!!
+ throws warning about some translation not being found , but loads it later down the log... appears on every restart
+ have downloaded a ubuntu iso with no problems, extent of testing thus far
+ untested with existing config files
+ unsure about dependency `libssl1.0.0` as to whether it a pip related dependency or otherwise
+ openssl dependency is satisfied as part of main deluge pull via python3-openssl from ppa.
+ `-d` switch added to run file for deluge-web as it keeps respawning without it on version 2.x