### PR TITLE
Update image to Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:focal
 
 # set version label
 ARG BUILD_DATE
@@ -17,9 +17,9 @@ RUN \
  apt-get install -y \
 	gnupg && \
  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
- echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
- echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-focal
 
 # set version label
 ARG BUILD_DATE
@@ -17,9 +17,9 @@ RUN \
  apt-get install -y \
 	gnupg && \
  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
- echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
- echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-focal
 
 # set version label
 ARG BUILD_DATE
@@ -17,9 +17,9 @@ RUN \
  apt-get install -y \
 	gnupg && \
  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C5E6A5ED249AD24C && \
- echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
- echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu bionic main" >> \
+ echo "deb-src http://ppa.launchpad.net/deluge-team/stable/ubuntu focal main" >> \
 	/etc/apt/sources.list.d/deluge.list && \
  echo "**** install packages ****" && \
  apt-get update && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,6 +48,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "25.02.21:", desc: "Update base image to Ubuntu Focal." }
   - { date: "23.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }
   - { date: "09.05.19:", desc: "Add python3 requests and future modules." }
   - { date: "24.08.19:", desc: "Add ability to set LogLevel for Deluge." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

## Description:
Current image is using Bionic Ubuntu wich uses a very old `libtorrent-rasterbar9` (version 1.1.5 released on Oct 14 2017). This build has a lot of bugfixes since then. Focal is using the far more up to date `libtorrent-rasterbar9` version 1.1.13 released on april 27 2019

## Benefits of this PR and context:
This PR solves a lot of libtorrent issues

## How Has This Been Tested?
Building and lauching the image with an allready functionning configuration

