### PR TITLE
readme-vars: compose: ports: udp definition valid

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -29,7 +29,7 @@ param_usage_include_ports: true
 param_ports:
   - { external_port: "8112", internal_port: "8112", port_desc: "Port for webui" }
   - { external_port: "6881", internal_port: "6881", port_desc: "Inbound torrent traffic (See App Setup)" }
-  - { external_port: "6881/udp", internal_port: "6881/udp", port_desc: "Inbound torrent traffic (See App Setup)" }
+  - { external_port: "6881", internal_port: "6881/udp", port_desc: "Inbound torrent traffic (See App Setup)" }
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use"}


### PR DESCRIPTION
Fixes
Invalid port "6881/udp:6881/udp", should be [[remote_ip:]remote_port[-[82/86]
port]:]port[/protocol]

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-deluge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications
<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
The `/udp` is more like a modifier, as such, imo it should have a separate field in the yml.

## Benefits of this PR and context:
docker-compose snippet would actually work