### PR TITLE
Adds env variable for changing log location

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ services:
       - PGID=1000
       - TZ=Europe/London
       - DELUGE_LOGLEVEL=error #optional
+      - DELUGED_LOGFILE=/config/deluged.log #optional
     volumes:
       - /path/to/deluge/config:/config
       - /path/to/your/downloads:/downloads
@@ -108,6 +109,7 @@ docker run -d \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e DELUGE_LOGLEVEL=error `#optional` \
+  -e DELUGED_LOGFILE=/config/deluged.log `#optional` \
   -p 8112:8112 \
   -p 6881:6881 \
   -p 6881:6881/udp \
@@ -130,6 +132,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use |
 | `-e DELUGE_LOGLEVEL=error` | set the loglevel output when running Deluge, default is info for deluged and warning for delgued-web |
+| `-e DELUGED_LOGFILE=/config/deluged.log` | set the file to use for logs when running deluged, default is logging to stdout |
 | `-v /config` | deluge configs |
 | `-v /downloads` | torrent download directory |
 
@@ -242,6 +245,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **07.30.21:** - Add logfile environment variable
 * **07.06.21:** - Remove host networking from readme examples
 * **23.01.21:** - Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information.
 * **09.05.19:** - Add python3 requests and future modules.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -37,6 +37,7 @@ param_env_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "DELUGE_LOGLEVEL", env_value: "error", desc: "set the loglevel output when running Deluge, default is info for deluged and warning for delgued-web"}
+  - { env_var: "DELUGED_LOGFILE", env_value: "/config/deluged.log", desc: "set the file to use for logs when running deluged, default is logging to stdout"}
 
 # application setup block
 app_setup_block_enabled: true
@@ -46,11 +47,12 @@ app_setup_block: |
   To change the password (recommended) log in to the web interface and go to Preferences->Interface->Password.
 
   Change the downloads location in the webui in Preferences->Downloads and use /downloads for completed downloads.
-  
+
   Change the inbound port to 6881 (or whichever port you've mapped for the container) under Preferences->Network, otherwise random ports will be used.
 
 # changelog
 changelogs:
+  - { date: "07.30.21:", desc: "Add logfile environment variable" }
   - { date: "07.06.21:", desc: "Remove host networking from readme examples" }
   - { date: "23.01.21:", desc: "Deprecate `UMASK_SET` in favor of UMASK in baseimage, see above for more information." }
   - { date: "09.05.19:", desc: "Add python3 requests and future modules." }

--- a/root/etc/services.d/deluged/run
+++ b/root/etc/services.d/deluged/run
@@ -1,11 +1,16 @@
 #!/usr/bin/with-contenv bash
 
 DELUGE_LOGLEVEL=${DELUGE_LOGLEVEL:-info}
+DELUGE_REAL_LOGFILE=""
 
 if [ -n "${UMASK_SET}" ] && [ -z "${UMASK}" ]; then
   echo -e "You are using a legacy method of defining umask\nplease update your environment variable from UMASK_SET to UMASK\nto keep the functionality after July 2021"
   umask ${UMASK_SET}
 fi
+
+if [ -n "${DELUGED_LOGFILE}" ]; then
+    DELUGE_REAL_LOGFILE="-l ${DELUGED_LOGFILE}"
+fi
 exec \
 	s6-setuidgid abc /usr/bin/deluged -c /config \
-	-d --loglevel=${DELUGE_LOGLEVEL} -l /config/deluged.log
+	-d --loglevel=${DELUGE_LOGLEVEL} ${DELUGE_REAL_LOGFILE}


### PR DESCRIPTION
This commit adds an option for specifying the log file location deluged.  This change is necessary so that in a container orchestration system, the log can be easily sent to STDOUT.

Closes #120

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-deluge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Adds env variables for changing log locations

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This allows customizing the log location for the deluged daemon.  From what I could find in deluge documentation, this isn't a setting that can be changed in the config but only on invocation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the container myself both with the new env var and without.  It functioned as I expected.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://dev.deluge-torrent.org/wiki/Troubleshooting#EnableDelugeLogging