### PR TITLE
Fix ownership check in 30-config

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -6,7 +6,7 @@ chown -R abc:abc \
 
 # chown download directory if currently not set to abc
 if [[ -d /downloads ]]; then
-    if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then
+    if [[ "$(stat -c '%u' /downloads)" != "$(id -u abc)" ]]; then
         chown -R abc:abc /downloads
     fi
 fi


### PR DESCRIPTION
Small fix to 30-config script, making it check the user **id** instead of the user **name** of /download folder before changing its owner.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-deluge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Right now /var/run/s6/etc/cont-init.d/30-config checks if the /download folder is owned by a user named "abc" before eventually trying to change its ownership.
The problem is, if running docker-deluge with PUID=0 and PGID=0, user root and abc will have the same uid and gid (but different names, obviously):
```
root@454748e39829:/# egrep "^(abc|root)" /etc/passwd
root:x:0:0:root:/root:/bin/ash
abc:x:0:0::/config:/bin/false
```

## Benefits of this PR and context:
By checking for UID instead of user name, it should correctly detect that root and abc share the same UID and skip the overwrite of /downloads ownership in the above case, which can save quite a bit of time at startup.
At the same time it won't affect all the other cases when the folder is not owned by abc, as UIDs are expected to be different.