### PR TITLE
GeoIP IPFS URL Change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN \
   echo "**** grab GeoIP database ****" && \
   curl -o \
     /usr/share/GeoIP/GeoIP.dat -L \
-    "https://ipfs.infura.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
+    "https://infura-ipfs.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -54,7 +54,7 @@ RUN \
   echo "**** grab GeoIP database ****" && \
   curl -o \
     /usr/share/GeoIP/GeoIP.dat -L \
-    "https://ipfs.infura.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
+    "https://infura-ipfs.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -54,7 +54,7 @@ RUN \
   echo "**** grab GeoIP database ****" && \
   curl -o \
     /usr/share/GeoIP/GeoIP.dat -L \
-    "https://ipfs.infura.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
+    "https://infura-ipfs.io/ipfs/QmWTWcPRRbADZcLcJeANZmcJZNrcpmuQgKYBi6hGdddtC6" && \
   echo "**** cleanup ****" && \
   apk del --purge \
     build-dependencies && \

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **22.11.22:** - Update GeoIP URL for new IPFS domain
 * **29.08.22:** - Rebase to Alpine Edge again to follow latest releases.
 * **12.08.22:** - Bump unrar to 6.1.7.
 * **16.06.22:** - Rebase to Alpine 3.16 from edge.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
-* **22.11.22:** - Update GeoIP URL for new IPFS domain
 * **29.08.22:** - Rebase to Alpine Edge again to follow latest releases.
 * **12.08.22:** - Bump unrar to 6.1.7.
 * **16.06.22:** - Rebase to Alpine 3.16 from edge.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "22.11.22:", desc: "Update GeoIP URL for new IPFS domain." }
   - { date: "29.08.22:", desc: "Rebase to Alpine Edge again to follow latest releases." }
   - { date: "12.08.22:", desc: "Bump unrar to 6.1.7." }
   - { date: "16.06.22:", desc: "Rebase to Alpine 3.16 from edge." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-deluge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
GeoIP.dat pull from domain ipfs.infura.io isn't active anymore. Uses infura-ipfs.io now.

## Benefits of this PR and context:
Addresses https://github.com/linuxserver/docker-deluge/issues/168
Incorporates README and Dockerfile armhf, aarch64 changes as recommended by https://github.com/linuxserver/docker-deluge/pull/167#issuecomment-1301366415

## How Has This Been Tested?
Old URL doesn't work, new URL works

## Source / References: