### PR TITLE
Add optional port 58846 to readme

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,9 @@ param_env_vars:
 opt_param_usage_include_env: true
 opt_param_env_vars:
   - { env_var: "DELUGE_LOGLEVEL", env_value: "error", desc: "set the loglevel output when running Deluge, default is info for deluged and warning for delgued-web"}
+opt_param_usage_include_ports: true
+opt_param_ports:
+  - { external_port: "58846", internal_port: "58846", port_desc: "Default deluged port for thin client connectivity"}
 
 # application setup block
 app_setup_block_enabled: true
@@ -48,6 +51,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "07.12.23:", desc: "Add optional port 58846 to readme for thin client connectivity."}
   - { date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar)."}
   - { date: "10.08.23:", desc: "Bump unrar to 6.2.10."}
   - { date: "30.06.23:", desc: "Bump unrar to 6.2.8, deprecate armhf as per [https://www.linuxserver.io/armhf](https://www.linuxserver.io/armhf)." }


### PR DESCRIPTION
 - [X] I have read the [contributing](https://github.com/linuxserver/docker-deluge/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
port 58846 is for allowing remote thin clients to connect and was not mentioned in our readme. 

## Benefits of this PR and context:
Helpful to users

## How Has This Been Tested?
N/A

## Source / References:
Closes https://github.com/linuxserver/docker-deluge/issues/190